### PR TITLE
[ADD] Append the actual Halcyon License.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,0 @@
-Copyright (C) Jack Meng 2022
-All rights served to the copyright holders.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,159 @@
+<!-- Yay, no errors, warnings, or alerts! -->
+  
+<h1 align="center"> <strong><span style="text-decoration:underline;">Halcyon 2.0 License</span></strong> </h1>
+
+<div align="center">
+<p style="text-align: right">
+Version 2.0, November 2022</p>
+
+
+<p style="text-align: right">
+Copyright © Jack Meng 2020-2022</p>
+
+_A safe-permissive license that enables friendly end-user consumption_
+</div>
+<hr>
+You may only use the bundled source/binary(s) only in compliance with this LICENSE.
+
+<pre align="center" style="text-align:center">
+  
+Copyright © [YYYY] [NAMES]
+All rights reserved to the above copyright holder(s).
+  
+</pre>
+ 
+This license with all subsiding terms & conditions applies to all forms (source and/or binary, without or without modifications) for USE, REPRODUCTION, MODIFICATION, & DISTRIBUTION.
+
+Notice: This license covers only SOURCE & BINARY Software; however it only has a single clause protecting any other files. Files and artifacts that fall under “resources” must be labeled under a different license in order to be fully protected if need be. [See Clause 11]
+
+<hr>
+
+<h3 align="center"> LICENSE’S TERMS & CONDITIONS: </h3>
+
+## 1. **Retention of Copyright**
+
+Source: All deriving works that directly modify the original software must reproduce the above copyright notice including this list of terms & conditions in FULL (raw retention).
+
+Binary: All subsiding binaries that have been compiled by third-party roots must be able to reproduce the above copyright notices including this list of terms & conditions. Either via accompanied documentation or some other format that provides the user with direct access to these terms & conditions.
+
+In no way shall any derivations of this software be sub-licensed in any way except for files related to clause 11.
+
+
+
+## 2. **Liability**
+
+In no event shall the authors or copyright holders be liable for any claim, damage, or other liabilities, whether in an action of contract, tort, or otherwise, arising from, out of, or in connection with the software or the use or other dealings in the software.
+
+You accept that the software bundled may include but is not limited the to:
+
+
+
+* Incompatibility with your system(s)
+* Potential malfunctions
+* Bugs
+
+## 3. **Trademarking, Trademarks**
+
+Trademarking of trade names, service marks, trademarks, and/or product names of the copyright holders except for descriptive purposes titling the parent roots.
+
+## 4. **Modification via plugin work**
+
+Plugin integration with the root software can be alienated from this license. However, if the desired plugin requires in any form THIS software to be bundled with it or requires it before the bundled software links/loads it, this license must be applied.
+
+By creating a plugin, you expect that no matter your purpose, your software is NOT TRUSTED. By creating potentially adverse/malicious plugins & software to be loaded by the bundled software, you are being exposed to potential damages that must be dealt with out of this LICENSE and its stated copyright holders & authors.
+
+Plug-ins loaded by the program CAN NOT AND MUST NOT modify any resources that violate the authors’ placed licenses or those construing with this license’s license.
+
+## 5. **Modification via source work**
+
+Direct modification of the source software must retain this license. All source versions must contain a file titled “ATTRIBUTIONS” which provides literal attributions to works. In this file, you may state changes made, previous attributions (fork of a fork), and your own attribution to your modifications. This license file shall serve as a literal marker of attributions made.
+
+By creating and modifying, you also show your compliance to this license and acknowledge the risks, terms & conditions, and your role.
+
+In no way shall this ATTRIBUTIONS file be used to restrict access to other contributors, it must only serve as a marker and not construe with the license and its overall accessibility. 
+
+If there is already an ATTRIBUTIONS file, you may append it to it.
+
+You pledge that your modifications are safe, reliable, and original. In no way shall your modifications cause adverse/malicious intents (unless it is a bug related to very specific system supports or some kind of third-party dependency used by the bundled software). Reliable in that, you have tested your modifications against test cases and have proven that it shall work against most targeted platforms. Original in that your proposals have not been duplicated, your idea wasn’t a deprecated feature, etc..
+
+
+## 6. **Source Permissiveness**
+
+The authors and copyright holders may restrict access to certain content parts. This does not grant you legal ability to modify & redistribute, but grants you modification for private use ONLY of that specific part.
+
+You may only use this bundled software as a reference and in no way directly restate the contents of IT.
+
+Unless required by applicable law or agreed in writing, content distributed under this license is provided “as is”:
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+
+
+
+## 7. **Warranties**
+
+There shall be no third party imposed fees and royalties required for any versions of the bundled software. However, plugin authors may impose their own fee if need be.
+
+
+
+## 8. **Consumption**
+
+The end user is allowed to modify, inspect, redistribute the bundled software only in compliance with this LICENSE. By utilizing the software in any means, be it executing it, viewing its source/binary form, redistributing it, etc. the end-user shows his or her compliance to this LICENSE.
+
+You accept that this software is not perfect and may contain bugs. This means it is your duty, as the end-user, to back up data if the bundled software calls for modification of said data.
+
+By utilizing any built in plugin loading functionalities, you also acknowledge that the original authors & copyright holders have no warranties, liability claims, and protection for you against any plugins that are created maliciously. The end user must accept the risks of knowing the potential risks of using them, distinguishing them properly. Damages caused by third party plugins loaded by the bundled software can only be dealt with by the consumer and the plugin author(s), and
+
+ will and cannot be affiliated with the authors & copyright holders of this license.
+
+
+
+## 9. **Redistribution**
+
+Third-party redistributions and authors may only redistribute under the terms that they:
+
+
+
+1. Cannot charge any form of royalties/fees.
+2. Disclose full origination
+3. Cannot exclude any person or persons from accessing said modifications/redistributions
+4. In no way construes or violate the terms & conditions within this license.
+5. Full source is disclosed, including the original documentations & source code attributes
+
+## **10.   Patent Claims & License(s)**
+
+This license is not provided with a patent claim, and users besides the original authors and license holders are not granted any patent claims & rights.
+
+## **11.   Resource(s)**
+
+Check RESOURCE_LICENSE.md for Halcyon's software resource license.
+
+_This clause only comes into effect if the original license holder DOES NOT provide a secondary license for resources and prefers to use this license as a whole to protect their work._
+
+This license does not fully protect any resource files (e.g. Image Files, Archive Files, Raw Documents *.doc, *.docx, *.pdf, etc.)
+
+All works are credited under a subcategory of licenses that should be made aware to the original authors & license holders. However, works that do not provide another license shall follow under the following declaration:
+
+
+
+1. Said works must be attributed clearly in any derivations of work
+2. Derivations of this software may not have these resources modified in any (except those that do not modify the original contents, e.g. file name, file date)
+3. Use of this content outside of the bundled software is not allowed unless stated. This means you are not allowed to use said content to promote elsewhere either for the authors & license holders OR for any other content.
+4. Acknowledgment that these resource files may use patented file formats or proprietary formats & you acknowledge the potential legal risks
+
+<h3 align="center"> END LICENSE’S TERMS & CONDITIONS </h3>
+
+<h3 align="center"> APPENDIX: </h3>
+
+**Reuse of license**
+
+If you wish to append this license or use this license in your own work, you simply change the above copyright notice:
+
+_Copyright © [YYYY] [NAMES]_
+
+Replace [YYYY] (without brackets) with the year
+
+Replace [NAMES] (without brackets) with all intended authors and license holders.
+
+By using this license, you acknowledge the potential legal risks and the purpose this license serves.
+
+<h3 align="center"> END APPENDIX </h3>


### PR DESCRIPTION
This is official License that should be packaged with all versions of Halcyon from now on. 

The full disclosure of the original all rights reserved license will not apply for any version from now on, even those that are before this change


Signed-off-by: Jack Meng <jackmeng0814@gmail.com>